### PR TITLE
Add package.json file with linters + scripts

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -44,6 +44,7 @@
 	"disallowSpacesInsideParentheses": true,
 	"disallowTrailingComma": true,
 	"disallowTrailingWhitespace": "ignoreEmptyLines",
+	"excludeFiles": ["node_modules/**"],
 	"requireBlocksOnNewline": true,
 	"requireCamelCaseOrUpperCaseIdentifiers": true,
 	"requireCapitalizedConstructors": true,

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "scripts": {
+    "eslint": "eslint .",
+    "jscs": "jscs ."
+  },
+  "devDependencies": {
+    "eslint": "^0.18.0",
+    "jscs": "^1.12.0"
+  }
+}


### PR DESCRIPTION
The `package.json` file contains ESLint and JSCS as dev dependencies, and has script entries to run them locally:

ESLint:

``` bash
npm run eslint
```

JSCS:

``` bash
npm run jscs
```
